### PR TITLE
Drop support for IE8

### DIFF
--- a/app/templates/files/component.mustache.html
+++ b/app/templates/files/component.mustache.html
@@ -8,4 +8,4 @@
   Try to have one enclosing tag around your component and add the components
   name as a class to it.
 -->
-<div <%= componentName %>></div>
+<<%= componentName %>></<%= componentName %>>


### PR DESCRIPTION
We can safely use [E]lement directives since we no longer support IE8.
